### PR TITLE
recall models' readme

### DIFF
--- a/models/recall/gru4rec/README.md
+++ b/models/recall/gru4rec/README.md
@@ -140,7 +140,7 @@ runner:
 
 ### 运行
 ```
-python -m paddlerec.run -m paddlerec.models.recall.gru4rec
+python -m paddlerec.run -m models/recall/gru4rec/config.yaml
 ```
 
 ### 结果展示

--- a/models/recall/word2vec/README.md
+++ b/models/recall/word2vec/README.md
@@ -184,7 +184,7 @@ python infer.py --test_dir ./data/test --dict_path ./data/dict/word_id_dict.txt 
 
 ### 运行
 ```
-python -m paddlerec.run -m paddlerec.models.recall.word2vec
+python -m paddlerec.run -m models/recall/word2vec/config.yaml
 ```
 
 ### 结果展示

--- a/models/recall/youtube_dnn/README.md
+++ b/models/recall/youtube_dnn/README.md
@@ -107,7 +107,7 @@ python infer.py --use_gpu 1 --test_epoch 19 --inference_model_dir ./inference_yo
 ```
 ### 运行
 ```
-python -m paddlerec.run -m paddlerec.models.recall.youtube_dnn
+python -m paddlerec.run -m models/recall/youtube_dnn/config.yaml
 ```
 
 ### 结果展示


### PR DESCRIPTION
run_command bug fix: 
from ```python -m paddlerec.run -m paddlerec.models.recall.word2vec``` to ```python -m paddlerec.run -m models/recall/word2vec/config.yaml```