### PR TITLE
fix first batch can't output

### DIFF
--- a/core/trainers/framework/runner.py
+++ b/core/trainers/framework/runner.py
@@ -199,7 +199,7 @@ class RunnerBase(object):
                             v]).tolist()
                     runner_results.append(batch_runner_result)
 
-                    if batch_id % fetch_period == 0 and batch_id != 0:
+                    if batch_id % fetch_period == 0:
                         end_time = time.time()
                         seconds = end_time - begin_time
                         metrics_logging = metrics[:]


### PR DESCRIPTION
修复了第一个batch无法输出的问题，第一个batch的batch_id=0，原本会被直接排除在输出之外，现在删掉这个排除的动作。在训练模型的时候可以得到完整的测试集预测值，但是由于0%任何数都等于0，故第一个batch无论如何都会被打印出来.
示例：
当yaml中设置print_interval=3时
原本前10个batch中会显示第3，6，9个batch的数据
现在前10个batch中会显示第0，3，6，9个batch的数据