### PR TITLE
change run.sh to run.py

### DIFF
--- a/models/rank/deepfm/data/run.py
+++ b/models/rank/deepfm/data/run.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import platform
+import shutil
+os.system("python download_preprocess.py")
+shutil.move("./deepfm%2Ffeat_dict_10.pkl2", "sample_data/feat_dict_10.pkl2")
+
+os.mkdir("slot_train_data")
+file_name = []
+file_name = os.listdir("train_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat train_data/{} | python get_slot_data.py > slot_train_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type train_data\{} | python get_slot_data.py > slot_train_data\{}".
+            format(i, i))
+
+os.mkdir("slot_test_data")
+file_name = []
+file_name = os.listdir("test_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat test_data/{} | python get_slot_data.py > slot_test_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type test_data\{} | python get_slot_data.py > slot_test_data\{}".
+            format(i, i))

--- a/models/rank/dnn/data/run.py
+++ b/models/rank/dnn/data/run.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import platform
+os.system("sh download.sh")
+
+os.mkdir("slot_train_data_full")
+file_name = []
+file_name = os.listdir("train_data_full")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat train_data_full/{} | python get_slot_data.py > slot_train_data_full/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type train_data_full\{} | python get_slot_data.py > slot_train_data_full\{}".
+            format(i, i))
+
+os.mkdir("slot_test_data_full")
+file_name = []
+file_name = os.listdir("test_data_full")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat test_data_full/{} | python get_slot_data.py > slot_test_data_full/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type test_data_full\{} | python get_slot_data.py > slot_test_data_full\{}".
+            format(i, i))
+
+os.mkdir("slot_train_data")
+file_name = []
+file_name = os.listdir("train_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat train_data/{} | python get_slot_data.py > slot_train_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type train_data\{} | python get_slot_data.py > slot_train_data\{}".
+            format(i, i))
+
+os.mkdir("slot_test_data")
+file_name = []
+file_name = os.listdir("test_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat test_data/{} | python get_slot_data.py > slot_test_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type test_data\{} | python get_slot_data.py > slot_test_data\{}".
+            format(i, i))

--- a/models/rank/fm/data/run.py
+++ b/models/rank/fm/data/run.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import platform
+import shutil
+os.system("python download_preprocess.py")
+shutil.move("./deepfm%2Ffeat_dict_10.pkl2", "sample_data/feat_dict_10.pkl2")
+
+os.mkdir("slot_train_data")
+file_name = []
+file_name = os.listdir("train_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat train_data/{} | python get_slot_data.py > slot_train_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type train_data\{} | python get_slot_data.py > slot_train_data\{}".
+            format(i, i))
+
+os.mkdir("slot_test_data")
+file_name = []
+file_name = os.listdir("test_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat test_data/{} | python get_slot_data.py > slot_test_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type test_data\{} | python get_slot_data.py > slot_test_data\{}".
+            format(i, i))

--- a/models/rank/logistic_regression/data/run.py
+++ b/models/rank/logistic_regression/data/run.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import platform
+import shutil
+os.system("python download_preprocess.py")
+shutil.move("./deepfm%2Ffeat_dict_10.pkl2", "sample_data/feat_dict_10.pkl2")
+
+os.mkdir("slot_train_data")
+file_name = []
+file_name = os.listdir("train_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat train_data/{} | python get_slot_data.py > slot_train_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type train_data\{} | python get_slot_data.py > slot_train_data\{}".
+            format(i, i))
+
+os.mkdir("slot_test_data")
+file_name = []
+file_name = os.listdir("test_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat test_data/{} | python get_slot_data.py > slot_test_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type test_data\{} | python get_slot_data.py > slot_test_data\{}".
+            format(i, i))

--- a/models/rank/wide_deep/data/run.py
+++ b/models/rank/wide_deep/data/run.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import platform
+os.system("sh create_data.sh")
+
+os.mkdir("slot_train_data")
+file_name = []
+file_name = os.listdir("train_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat train_data/{} | python get_slot_data.py > slot_train_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type train_data\{} | python get_slot_data.py > slot_train_data\{}".
+            format(i, i))
+
+os.mkdir("slot_test_data")
+file_name = []
+file_name = os.listdir("test_data")
+sysstr = platform.system()
+if (sysstr == "Linux"):
+    for i in file_name:
+        os.system(
+            "cat test_data/{} | python get_slot_data.py > slot_test_data/{}".
+            format(i, i))
+if (sysstr == "Windows"):
+    for i in file_name:
+        os.system(
+            "type test_data\{} | python get_slot_data.py > slot_test_data\{}".
+            format(i, i))


### PR DESCRIPTION
针对反馈的windows用户无法获得全量数据的问题，我将数据处理中的run.sh换成了run.py，主要修复了windows下没有ls和cat这两个命令的问题。原脚本中调用的数据下载脚本，因为没有windows用户难以实现的命令，所以保留了下来。同时原先的run.sh文件也保留下来供linux用户一键启动。