### PR TITLE
QA make a CI

### DIFF
--- a/models/contentunderstanding/tagspace/agnews_reader.py
+++ b/models/contentunderstanding/tagspace/agnews_reader.py
@@ -21,10 +21,14 @@ class RecDataset(IterableDataset):
     def __init__(self, file_list, config):
         super(RecDataset, self).__init__()
         self.file_list = file_list
+        if config:
+            self.CE = config.get("runner.CE", False)
 
     def __iter__(self):
         full_lines = []
         self.data = []
+        if self.CE:
+            np.random.seed(12345)
         for file in self.file_list:
             with open(file, "r") as rf:
                 for l in rf:

--- a/models/contentunderstanding/tagspace/config.yaml
+++ b/models/contentunderstanding/tagspace/config.yaml
@@ -20,7 +20,7 @@ runner:
 
   use_gpu: False
   epochs: 1
-  print_interval: 1
+  print_interval: 10
   
   test_data_dir: "data/test_data"
   infer_reader_path: "agnews_reader"  # importlib format
@@ -28,6 +28,7 @@ runner:
   infer_load_path: "output_model_tagspace"
   infer_start_epoch: 0
   infer_end_epoch: 1
+  CE: True
 
 # hyper parameters of user-defined network
 hyper_parameters:

--- a/models/contentunderstanding/textcnn/dygraph_model.py
+++ b/models/contentunderstanding/textcnn/dygraph_model.py
@@ -87,8 +87,8 @@ class DygraphModel():
         correct = metrics_list[0].compute(prediction, label)
         metrics_list[0].update(correct)
 
-        # print_dict format :{'loss': loss} 
-        print_dict = None
+        print_dict = {'loss': loss}
+        # print_dict = None
         return loss, metrics_list, print_dict
 
     def infer_forward(self, dy_model, metrics_list, batch_data, config):

--- a/models/multitask/mmoe/dygraph_model.py
+++ b/models/multitask/mmoe/dygraph_model.py
@@ -93,8 +93,8 @@ class DygraphModel():
         metrics_list[1].update(
             preds=pred_marital.numpy(), labels=label_marital.numpy())
 
-        # print_dict format :{'loss': loss} 
-        print_dict = None
+        print_dict = {'loss': loss}
+        # print_dict = None
         return loss, metrics_list, print_dict
 
     def infer_forward(self, dy_model, metrics_list, batch_data, config):

--- a/models/rank/deepfm/dygraph_model.py
+++ b/models/rank/deepfm/dygraph_model.py
@@ -83,8 +83,8 @@ class DygraphModel():
         predict_2d = paddle.concat(x=[1 - pred, pred], axis=1)
         metrics_list[0].update(preds=predict_2d.numpy(), labels=label.numpy())
 
-        # print_dict format :{'loss': loss} 
-        print_dict = None
+        print_dict = {'loss': loss}
+        # print_dict = None
         return loss, metrics_list, print_dict
 
     def infer_forward(self, dy_model, metrics_list, batch_data, config):

--- a/models/rank/dnn/dygraph_model.py
+++ b/models/rank/dnn/dygraph_model.py
@@ -81,8 +81,8 @@ class DygraphModel():
         predict_2d = paddle.nn.functional.softmax(raw_pred_2d)
         metrics_list[0].update(preds=predict_2d.numpy(), labels=label.numpy())
 
-        # print_dict format :{'loss': loss}
-        print_dict = None
+        print_dict = {'loss': loss}
+        # print_dict = None
         return loss, metrics_list, print_dict
 
     def infer_forward(self, dy_model, metrics_list, batch_data, config):

--- a/models/rank/wide_deep/criteo_reader.py
+++ b/models/rank/wide_deep/criteo_reader.py
@@ -24,6 +24,7 @@ class RecDataset(IterableDataset):
         self.file_list = file_list
         if config:
             use_fleet = config.get("runner.use_fleet", False)
+            self.use_inference = config.get("runner.use_inference", False)
         else:
             use_fleet = False
         if use_fleet:
@@ -95,4 +96,7 @@ class RecDataset(IterableDataset):
                     output_list.append(
                         np.array(output[-1][1]).astype("float32"))
                     # list
-                    yield output_list
+                    if self.use_inference:
+                        yield output_list[1:]
+                    else:
+                        yield output_list

--- a/models/rank/wide_deep/dygraph_model.py
+++ b/models/rank/wide_deep/dygraph_model.py
@@ -84,8 +84,8 @@ class DygraphModel():
         predict_2d = paddle.concat(x=[1 - pred, pred], axis=1)
         metrics_list[0].update(preds=predict_2d.numpy(), labels=label.numpy())
 
-        # print_dict format :{'loss': loss} 
-        print_dict = None
+        print_dict = {'loss': loss}
+        #print_dict = None
         return loss, metrics_list, print_dict
 
     def infer_forward(self, dy_model, metrics_list, batch_data, config):

--- a/tools/paddle_infer.py
+++ b/tools/paddle_infer.py
@@ -70,7 +70,7 @@ def init_predictor(args):
                 precision_mode=paddle.inference.PrecisionType.Float32)
     else:
         config.disable_gpu()
-        # config.delete_pass("repeated_fc_relu_fuse_pass")
+        config.delete_pass("repeated_fc_relu_fuse_pass")
         config.set_cpu_math_library_num_threads(args.cpu_threads)
         if args.enable_mkldnn:
             config.enable_mkldnn()
@@ -88,7 +88,8 @@ def create_data_loader(args):
     sys.path.append(reader_path)
     #sys.path.append(os.path.abspath("."))
     reader_class = import_module(reader_file)
-    dataset = reader_class.RecDataset(file_list, config=None)
+    config = {"use_inference": True}
+    dataset = reader_class.RecDataset(file_list, config=config)
     loader = DataLoader(
         dataset, batch_size=batchsize, places=place, drop_last=True)
     return loader


### PR DESCRIPTION
1. wide_deep模型在使用paddle_infer时可以直接使用criteo_reader，无需手动更改
2. tagspace模型的config.yaml中添加CE参数，在reader中读取该参数使用随机种子固定训练过程
3. 验证wide_deep,deepfm,textcnn,tagspace,dnn,dssm,ncf，mmoe模型的loss，模型的demo数据集均为全量数据集的截取，并且在多次训练时每次训练都可以得到相同的loss，指标中没有loss的已添加。