### PR TITLE
MIND模型复线效果极差

### DIFF
--- a/models/recall/mind/mind_reader.py
+++ b/models/recall/mind/mind_reader.py
@@ -51,7 +51,6 @@ class RecDataset(IterableDataset):
         self.items = list(self.items)
 
     def __iter__(self):
-        random.seed(12345)
         while True:
             user_id_list = random.sample(self.users, self.batch_size)
             if self.count >= self.batches_per_epoch * self.batch_size:
@@ -61,7 +60,6 @@ class RecDataset(IterableDataset):
                 item_list = self.graph[user_id]
                 if len(item_list) <= 4:
                     continue
-                random.seed(12345)
                 k = random.choice(range(4, len(item_list)))
                 item_id = item_list[k]
 


### PR DESCRIPTION
MIND效果无法复线，原因是因为mind_reader.py中固定住了随机种子，而该实现中每一个batch的数据都是随机挑选的，这就导致会一直训练一个batch的数据，如果batch_size是128，就只会在这个batch上重复训练，所以效果很差。