### PR TITLE
[UPDATE REQUIREMENT FILE]limit jinja2 version of readthedocs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,3 +5,4 @@ paddlepaddle>=1.8
 zmq
 sphinx-markdown-tables
 recommonmark
+jinja2<3.1


### PR DESCRIPTION
限制构建readthedocs的依赖库jinja2的版本（<3.1），不然会报错