### PR TITLE
[TIPC] Add scripts for npu and xpu, test=master

### DIFF
--- a/test_tipc/configs/ensfm/paddle_infer.py
+++ b/test_tipc/configs/ensfm/paddle_infer.py
@@ -21,8 +21,9 @@ import logging
 import sys
 import re
 from importlib import import_module
+
 __dir__ = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.abspath(os.path.join(__dir__, '..')))
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../../../tools')))
 from utils.utils_single import load_yaml, load_dy_model_class, get_abs_model
 from utils.save_load import save_model, load_model
 from paddle.io import DistributedBatchSampler, DataLoader

--- a/test_tipc/configs/ensfm/to_static.py
+++ b/test_tipc/configs/ensfm/to_static.py
@@ -22,7 +22,8 @@ import importlib
 
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 # sys.path.append(__dir__)
-sys.path.append(os.path.abspath(os.path.join(__dir__, '..')))
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../../../tools')))
 
 from utils.utils_single import load_yaml, load_dy_model_class, get_abs_model, create_data_loader
 from utils.save_load import load_model, save_model, save_jit_model

--- a/test_tipc/configs/ensfm/train_infer_python.txt
+++ b/test_tipc/configs/ensfm/train_infer_python.txt
@@ -9,11 +9,11 @@ runner.model_save_path
 runner.train_batch_size:lite_train_lite_infer=2|whole_train_whole_infer=512|whole_infer=512|lite_train_whole_infer=2
 runner.infer_load_path:null
 train_model_name:lite_train_lite_infer=0|whole_train_whole_infer=500|whole_infer=500|lite_train_whole_infer=0
-runner.test_data_dir:test_tipc/data
-runner.train_data_dir:../../../test_tipc/data
+runner.test_data_dir:test_tipc/data/infer
+runner.train_data_dir:../../../test_tipc/data/train
 ##
 trainer:norm_train
-norm_train:-u tools/trainer.py -m ./models/recall/ensfm/config.yaml -o runner.print_interval=2
+norm_train:-u tools/trainer.py -m models/recall/ensfm/config.yaml -o runner.print_interval=2
 quant_train:null
 fpgm_train:null
 distill_train:null
@@ -27,7 +27,7 @@ null:null
 ===========================infer_params===========================
 runner.model_save_path:
 runner.model_init_path:
-norm_export:-u ./to_static.py -m ./models/recall/ensfm/config_test.yaml -o runner.CE=true
+norm_export:-u test_tipc/configs/ensfm/to_static.py -m models/recall/ensfm/config.yaml -o runner.CE=true
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -37,7 +37,7 @@ null:null
 infer_model:test_tipc/save_ensfm_model
 infer_export:null
 infer_quant:False
-inference:-u ./paddle_infer.py --model_name=ensfm --reader_file=models/recall/ensfm/movielens_reader.py
+inference:-u test_tipc/configs/ensfm/paddle_infer.py --model_name=ensfm --reader_file=models/recall/ensfm/movielens_reader.py
 --use_gpu:True|False
 --enable_mkldnn:True|False
 --cpu_threads:1|6

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -14,9 +14,8 @@ lines=(${dataline})
 # The training params
 model_name=$(func_parser_value "${lines[1]}")
 
-# clear dataset and output
+# clear dataset
 rm -rf ./test_tipc/data
-# rm -rf ./test_tipc/output
 
 if [ ${model_name} == "dnn" ]; then
     # prepare pretrained weights and dataset 

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -16,7 +16,7 @@ model_name=$(func_parser_value "${lines[1]}")
 
 # clear dataset and output
 rm -rf ./test_tipc/data
-rm -rf ./test_tipc/output
+# rm -rf ./test_tipc/output
 
 if [ ${model_name} == "dnn" ]; then
     # prepare pretrained weights and dataset 

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -136,7 +136,7 @@ if [ ${MODE} = "klquant_whole_infer" ]; then
     infer_value1=$(func_parser_value "${lines[17]}")
 fi
 
-LOG_PATH="./test_tipc/output"
+LOG_PATH="./test_tipc/output/${model_name}"
 mkdir -p ${LOG_PATH}
 status_log="${LOG_PATH}/results_python.log"
 

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[3]}
+    echo ${tmp}
+}
+
+function func_parser_execute_python() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[1]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to npu in tipc txt configs
+sed -i "s/runner.use_gpu/runner.use_npu/g" $FILENAME
+sed -i "s/--use_gpu/--use_npu/g" $FILENAME
+sed -i "s/--enable_tensorRT:False|True/--enable_tensorRT:False/g" $FILENAME
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to npu in execution script
+sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# replace gpu to npu in trainer.py
+trainer_py=$(func_parser_value "${lines[15]}")
+trainer_config=$(func_parser_execute_python ${trainer_py})
+sed -i 's/config.get(\"runner.use_gpu\", True)/config.get(\"runner.use_gpu\", False)/g' "$REPO_ROOT_PATH/$trainer_config"
+
+# replace gpu to npu in to_static.py
+to_static_py=$(func_parser_value "${lines[29]}")
+to_static_config=$(func_parser_execute_python ${to_static_py})
+if [[ $to_static_config =~ "test_tipc" ]];then
+    echo "replace in to_static.py"
+    sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$to_static_config"
+    sed -i 's/'"'"'gpu'"'"'/'"'"'npu'"'"'/g' "$REPO_ROOT_PATH/$to_static_config"
+fi
+
+# replace gpu to npu in paddle_infer.py
+inference_py=$(func_parser_value "${lines[39]}")
+inference_config=$(func_parser_execute_python ${inference_py})
+if [[ $inference_config =~ "test_tipc" ]]; then
+    echo "replace in paddle_infer.py"
+    sed -i 's/config.enable_use_gpu(1000, 0)/config.enable_use_npu()/g' "$REPO_ROOT_PATH/$inference_config"
+    sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$inference_config"
+    sed -i 's/'"'"'gpu'"'"'/'"'"'npu'"'"'/g' "$REPO_ROOT_PATH/$inference_config"
+fi
+
+# replace training config file
+grep -n './models/.*yaml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do 
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    echo $trainer_config
+    sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$trainer_config"
+done
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -27,9 +27,7 @@ REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
 FILENAME=$1
 
 # change gpu to npu in tipc txt configs
-sed -i "s/gpu_list:0|-1/gpu_list:0/g" $FILENAME
-sed -i "s/runner.use_gpu:True|False/runner.use_npu:True/g" $FILENAME
-sed -i "s/--use_gpu:True|False/--use_npu:True/g" $FILENAME
+sed -i "s/runner.use_gpu/runner.use_npu/g" $FILENAME
 sed -i "s/--use_gpu/--use_npu/g" $FILENAME
 sed -i "s/--enable_tensorRT:False|True/--enable_tensorRT:False/g" $FILENAME
 sed -i "s/--enable_tensorRT:True|False/--enable_tensorRT:False/g" $FILENAME

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -27,9 +27,12 @@ REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
 FILENAME=$1
 
 # change gpu to npu in tipc txt configs
-sed -i "s/runner.use_gpu/runner.use_npu/g" $FILENAME
+sed -i "s/gpu_list:0|-1/gpu_list:0/g" $FILENAME
+sed -i "s/runner.use_gpu:True|False/runner.use_npu:True/g" $FILENAME
+sed -i "s/--use_gpu:True|False/--use_npu:True/g" $FILENAME
 sed -i "s/--use_gpu/--use_npu/g" $FILENAME
 sed -i "s/--enable_tensorRT:False|True/--enable_tensorRT:False/g" $FILENAME
+sed -i "s/--enable_tensorRT:True|False/--enable_tensorRT:False/g" $FILENAME
 sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
 dataline=`cat $FILENAME`
 
@@ -48,18 +51,14 @@ sed -i 's/config.get(\"runner.use_gpu\", True)/config.get(\"runner.use_gpu\", Fa
 # replace gpu to npu in to_static.py
 to_static_py=$(func_parser_value "${lines[29]}")
 to_static_config=$(func_parser_execute_python ${to_static_py})
-if [[ $to_static_config =~ "test_tipc" ]];then
-    echo "replace in to_static.py"
-    sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$to_static_config"
-    sed -i 's/'"'"'gpu'"'"'/'"'"'npu'"'"'/g' "$REPO_ROOT_PATH/$to_static_config"
-fi
+sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$to_static_config"
+sed -i 's/'"'"'gpu'"'"'/'"'"'npu'"'"'/g' "$REPO_ROOT_PATH/$to_static_config"
 
 # replace gpu to npu in paddle_infer.py
 inference_py=$(func_parser_value "${lines[39]}")
 inference_config=$(func_parser_execute_python ${inference_py})
 if [[ $inference_config =~ "test_tipc" ]]; then
-    echo "replace in paddle_infer.py"
-    sed -i 's/config.enable_use_gpu(1000, 0)/config.enable_use_npu()/g' "$REPO_ROOT_PATH/$inference_config"
+    sed -i 's/config.enable_use_gpu(1000, 0)/config.enable_npu()/g' "$REPO_ROOT_PATH/$inference_config"
     sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$inference_config"
     sed -i 's/'"'"'gpu'"'"'/'"'"'npu'"'"'/g' "$REPO_ROOT_PATH/$inference_config"
 fi

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -59,6 +59,8 @@ if [[ $inference_config =~ "test_tipc" ]]; then
     sed -i 's/config.enable_use_gpu(1000, 0)/config.enable_npu()/g' "$REPO_ROOT_PATH/$inference_config"
     sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$inference_config"
     sed -i 's/'"'"'gpu'"'"'/'"'"'npu'"'"'/g' "$REPO_ROOT_PATH/$inference_config"
+else
+    sed -i 's/"--use_gpu", type=str2bool, default=True/"--use_gpu", type=str2bool, default=False/g' "$REPO_ROOT_PATH/$inference_config"
 fi
 
 # replace training config file

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[3]}
+    echo ${tmp}
+}
+
+function func_parser_execute_python() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[1]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to npu in tipc txt configs
+sed -i "s/runner.use_gpu/runner.use_xpu/g" $FILENAME
+sed -i "s/--use_gpu/--use_xpu/g" $FILENAME
+sed -i "s/--enable_tensorRT:False|True/--enable_tensorRT:False/g" $FILENAME
+sed -i "s/--enable_tensorRT:True|False/--enable_tensorRT:False/g" $FILENAME
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to npu in execution script
+sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# replace gpu to npu in trainer.py
+trainer_py=$(func_parser_value "${lines[15]}")
+trainer_config=$(func_parser_execute_python ${trainer_py})
+sed -i 's/config.get(\"runner.use_gpu\", True)/config.get(\"runner.use_gpu\", False)/g' "$REPO_ROOT_PATH/$trainer_config"
+
+# replace gpu to npu in to_static.py
+to_static_py=$(func_parser_value "${lines[29]}")
+to_static_config=$(func_parser_execute_python ${to_static_py})
+sed -i 's/use_gpu/use_xpu/g' "$REPO_ROOT_PATH/$to_static_config"
+sed -i 's/'"'"'gpu'"'"'/'"'"'xpu'"'"'/g' "$REPO_ROOT_PATH/$to_static_config"
+
+# replace gpu to npu in paddle_infer.py
+inference_py=$(func_parser_value "${lines[39]}")
+inference_config=$(func_parser_execute_python ${inference_py})
+if [[ $inference_config =~ "test_tipc" ]]; then
+    sed -i 's/config.enable_use_gpu(1000, 0)/config.enable_xpu(100)/g' "$REPO_ROOT_PATH/$inference_config"
+    sed -i 's/use_gpu/use_xpu/g' "$REPO_ROOT_PATH/$inference_config"
+    sed -i 's/'"'"'gpu'"'"'/'"'"'xpu'"'"'/g' "$REPO_ROOT_PATH/$inference_config"
+fi
+
+# replace training config file
+grep -n './models/.*yaml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do 
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    echo $trainer_config
+    sed -i 's/use_gpu/use_xpu/g' "$REPO_ROOT_PATH/$trainer_config"
+done
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -59,6 +59,8 @@ if [[ $inference_config =~ "test_tipc" ]]; then
     sed -i 's/config.enable_use_gpu(1000, 0)/config.enable_xpu(100)/g' "$REPO_ROOT_PATH/$inference_config"
     sed -i 's/use_gpu/use_xpu/g' "$REPO_ROOT_PATH/$inference_config"
     sed -i 's/'"'"'gpu'"'"'/'"'"'xpu'"'"'/g' "$REPO_ROOT_PATH/$inference_config"
+else
+    sed -i 's/"--use_gpu", type=str2bool, default=True/"--use_gpu", type=str2bool, default=False/g' "$REPO_ROOT_PATH/$inference_config"
 fi
 
 # replace training config file

--- a/tools/paddle_infer.py
+++ b/tools/paddle_infer.py
@@ -32,13 +32,16 @@ from paddle.inference import create_predictor
 
 
 def parse_args():
+    def str2bool(v):
+        return v.lower() in ("true", "t", "1")
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_file", type=str)
     parser.add_argument("--params_file", type=str)
     parser.add_argument("--model_dir", type=str)
-    parser.add_argument("--use_gpu", type=str)
-    parser.add_argument("--use_npu", type=str)
-    parser.add_argument("--use_xpu", type=str)
+    parser.add_argument("--use_gpu", type=str2bool, default=False)
+    parser.add_argument("--use_npu", type=str2bool, default=False)
+    parser.add_argument("--use_xpu", type=str2bool, default=False)
     parser.add_argument("--data_dir", type=str)
     parser.add_argument("--reader_file", type=str)
     parser.add_argument("--batchsize", type=int)
@@ -50,12 +53,6 @@ def parse_args():
     parser.add_argument("--save_log_path", type=str, default="./output")
     parser.add_argument("--precision", type=str)
     args = parser.parse_args()
-    args.use_gpu = (True if args.use_gpu is not None and
-                    args.use_gpu.lower() == "true" else False)
-    args.use_npu = (True if args.use_npu is not None and
-                    args.use_npu.lower() == "true" else False)
-    args.use_xpu = (True if args.use_xpu is not None and
-                    args.use_xpu.lower() == "true" else False)                
     args.enable_mkldnn = (True
                           if args.enable_mkldnn.lower() == "true" else False)
     args.enable_tensorRT = (True if args.enable_tensorRT.lower() == "true" else
@@ -96,7 +93,7 @@ def init_predictor(args):
     elif args.use_npu:
         config.enable_npu()
     elif args.use_xpu:
-        config.enable_xpu(100)
+        config.enable_xpu()
     else:
         config.disable_gpu()
         config.set_cpu_math_library_num_threads(args.cpu_threads)
@@ -129,7 +126,7 @@ def main(args):
         place = paddle.set_device('gpu')
     elif args.use_npu:
         place = paddle.set_device('npu')
-    elif args.use_gpu:
+    elif args.use_xpu:
         place = paddle.set_device('xpu')
     else:
         place = paddle.set_device('cpu')

--- a/tools/paddle_infer.py
+++ b/tools/paddle_infer.py
@@ -38,6 +38,7 @@ def parse_args():
     parser.add_argument("--model_dir", type=str)
     parser.add_argument("--use_gpu", type=str)
     parser.add_argument("--use_npu", type=str)
+    parser.add_argument("--use_xpu", type=str)
     parser.add_argument("--data_dir", type=str)
     parser.add_argument("--reader_file", type=str)
     parser.add_argument("--batchsize", type=int)
@@ -53,6 +54,8 @@ def parse_args():
                     args.use_gpu.lower() == "true" else False)
     args.use_npu = (True if args.use_npu is not None and
                     args.use_npu.lower() == "true" else False)
+    args.use_xpu = (True if args.use_xpu is not None and
+                    args.use_xpu.lower() == "true" else False)                
     args.enable_mkldnn = (True
                           if args.enable_mkldnn.lower() == "true" else False)
     args.enable_tensorRT = (True if args.enable_tensorRT.lower() == "true" else
@@ -92,6 +95,8 @@ def init_predictor(args):
                 precision_mode=paddle.inference.PrecisionType.Float32)
     elif args.use_npu:
         config.enable_npu()
+    elif args.use_xpu:
+        config.enable_xpu(100)
     else:
         config.disable_gpu()
         config.set_cpu_math_library_num_threads(args.cpu_threads)
@@ -124,6 +129,8 @@ def main(args):
         place = paddle.set_device('gpu')
     elif args.use_npu:
         place = paddle.set_device('npu')
+    elif args.use_gpu:
+        place = paddle.set_device('xpu')
     else:
         place = paddle.set_device('cpu')
     args.place = place

--- a/tools/paddle_infer.py
+++ b/tools/paddle_infer.py
@@ -49,7 +49,8 @@ def parse_args():
     parser.add_argument("--save_log_path", type=str, default="./output")
     parser.add_argument("--precision", type=str)
     args = parser.parse_args()
-    args.use_gpu = (True if args.use_gpu.lower() == "true" else False)
+    args.use_gpu = (True if args.use_gpu is not None and
+                    args.use_gpu.lower() == "true" else False)
     args.use_npu = (True if args.use_npu is not None and
                     args.use_npu.lower() == "true" else False)
     args.enable_mkldnn = (True


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本:

```
# 准备小数据集
bash test_tipc/prepare.sh test_tipc/configs/aitm/train_infer_python.txt 'lite_train_lite_infer'
```

```
# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh \
     test_tipc/configs/aitm/train_infer_python.txt  'lite_train_lite_infer'
```

```
# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh \
     test_tipc/configs/aitm/train_infer_python.txt  'lite_train_lite_infer'
```