### PR TITLE
[paddlerec update] fix setup

### DIFF
--- a/uapi_rec/__init__.py
+++ b/uapi_rec/__init__.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import PaddleModel, Config
+import sys, os
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(__dir__)
+sys.path.append(os.path.abspath(os.path.join(__dir__, '..')))
+sys.path.append('../')
+print(sys.path)
+
+from base import PaddleModel, Config
 # Register models and suites
 # wide_deep 
-from .rank import register
+from rank import register

--- a/uapi_rec/__init__.py
+++ b/uapi_rec/__init__.py
@@ -23,3 +23,4 @@ from base import PaddleModel, Config
 # Register models and suites
 # wide_deep 
 from rank import register
+from rank import check_dataset

--- a/uapi_rec/__init__.py
+++ b/uapi_rec/__init__.py
@@ -17,7 +17,6 @@ __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
 sys.path.append(os.path.abspath(os.path.join(__dir__, '..')))
 sys.path.append('../')
-print(sys.path)
 
 from base import PaddleModel, Config
 # Register models and suites


### PR DESCRIPTION
通过添加绝对路径解决安装paddlerec后无法导入相关模块的错误