### PR TITLE
Recall model mind | b2i routing | softmax dim should be 2

### DIFF
--- a/models/recall/mind/net.py
+++ b/models/recall/mind/net.py
@@ -210,7 +210,7 @@ class Mind_Capsual_Layer(nn.Layer):
         for i in range(self.iters - 1):
             B_mask = paddle.where(mask, B, pad)
             # print(B_mask)
-            W = F.softmax(B_mask, axis=1)
+            W = F.softmax(B_mask, axis=2)
             W = paddle.unsqueeze(W, axis=2)
             high_capsule_tmp = paddle.matmul(W, low_capsule_new_nograd)
             # print(low_capsule_new_nograd.shape)


### PR DESCRIPTION
`B_mask`的尺寸为`(batch_size, 兴趣胶囊个数, 原始序列长度)`，softmax需要为原始序列中的各个物品向量生成融合权重w，因此softmax的维度应该为2而不是1。

dim=1时（现状），padding位置的权重值不为0:

**B_mask**:
```
[[ 0.14593406 , -1.09645927 ,  0.03486454 , ..., -4294967296.,
    -4294967296., -4294967296.],
 [ 0.58527076 ,  0.38395855 ,  0.03423365 , ..., -4294967296.,
    -4294967296., -4294967296.],
...
```

**W**:
```
[[[0.27838382, 0.06333959, 0.28643984, ..., 0.25000000,
    0.25000000, 0.25000000],
   [0.43196195, 0.27836370, 0.28625917, ..., 0.25000000,
    0.25000000, 0.25000000],
...
```

修改后，padding位置的权重值正确地为0：
**B_mask**:
```
[[[ 0.14593406 , -1.09645927 ,  0.03486454 , ..., -4294967296.,
     -4294967296., -4294967296.],
   [ 0.58527076 ,  0.38395855 ,  0.03423365 , ..., -4294967296.,
    -4294967296., -4294967296.],
...
```

**W**:
```
[[[0.03726962, 0.01075946, 0.03335170, ..., 0.00000000,
    0.00000000, 0.00000000],
   [0.09916992, 0.08108699, 0.05715676, ..., 0.00000000,
    0.00000000, 0.00000000],
...
```