### PR TITLE
fix wide_deep gpups error when run in py>3.7

### DIFF
--- a/models/rank/wide_deep/config_gpups.yaml
+++ b/models/rank/wide_deep/config_gpups.yaml
@@ -29,7 +29,7 @@ runner:
   sync_mode: "gpubox"
   thread_num: 30
   reader_type: "InmemoryDataset"  # DataLoader / QueueDataset / RecDataset / InmemoryDataset
-  pipe_command: "python3.7 models/rank/wide_deep/queuedataset_reader.py"
+  pipe_command: "python models/rank/wide_deep/queuedataset_reader.py"
   dataset_debug: False
   split_file_list: False
 


### PR DESCRIPTION
fix wide_deep gpups error when run in py>3.7